### PR TITLE
Improve validation in API and client

### DIFF
--- a/pages/api/generate.js
+++ b/pages/api/generate.js
@@ -9,7 +9,13 @@ export default async function handler(req, res) {
     return res.status(405).json({ error: "Method Not Allowed" });
   }
 
-  const { name, role } = req.body;
+  if (!process.env.OPENAI_API_KEY) {
+    console.error("OPENAI_API_KEY not configured");
+    return res.status(500).json({ error: "Server configuration error." });
+  }
+
+  const name = (req.body.name || "").trim();
+  const role = (req.body.role || "").trim();
 
   if (!name || !role) {
     return res.status(400).json({ error: "Name and role are required." });

--- a/pages/index.js
+++ b/pages/index.js
@@ -8,6 +8,14 @@ export default function Home() {
   const [error, setError] = useState("");
 
   async function generateBio() {
+    const trimmedName = name.trim();
+    const trimmedRole = role.trim();
+
+    if (!trimmedName || !trimmedRole) {
+      setError("Name and role are required.");
+      return;
+    }
+
     setLoading(true);
     setError("");
     setBio("");
@@ -16,7 +24,7 @@ export default function Home() {
       const response = await fetch("/api/generate", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name, role }),
+        body: JSON.stringify({ name: trimmedName, role: trimmedRole }),
       });
 
       const data = await response.json();


### PR DESCRIPTION
## Summary
- validate required fields on the client before calling the API
- trim fields and verify `OPENAI_API_KEY` on the server

## Testing
- `node --check pages/index.js`
- `node --check pages/api/generate.js`
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68572a51d3e0832788c49ba6841af8c4